### PR TITLE
Export Loc(..)

### DIFF
--- a/src/Data/Dwarf/ADT.hs
+++ b/src/Data/Dwarf/ADT.hs
@@ -7,6 +7,7 @@ module Data.Dwarf.ADT
   , Def(..), DefType(..)
   , TypeRef(..)
   , BaseType(..)
+  , Loc(..)
   , Typedef(..)
   , PtrType(..)
   , ConstType(..)


### PR DESCRIPTION
Loc and its constructors are now exported.

Currently it forces us to deal with low-level DWARF constructors (DW_OP_breg and the like in LocOP) but it is better than nothing :)
