### PR TITLE
Use ELF byte order for DWARF endianness.

### DIFF
--- a/dumpadt.hs
+++ b/dumpadt.hs
@@ -6,6 +6,6 @@ import qualified Data.Dwarf.Elf as Dwarf.Elf
 main :: IO ()
 main = do
   [filename] <- getArgs
-  (dwarf, warnings) <- Dwarf.Elf.parseElfDwarfADT Dwarf.LittleEndian filename
+  (dwarf, warnings) <- Dwarf.Elf.parseElfDwarfADT filename
   mapM_ print warnings
   print $ DwarfPretty.dwarf dwarf

--- a/dumpdwarf.hs
+++ b/dumpdwarf.hs
@@ -11,5 +11,5 @@ dieTree die = Node die . map dieTree $ Dwarf.dieChildren die
 main :: IO ()
 main = do
   [filename] <- getArgs
-  (_, (cuDies, _)) <- loadElfDwarf Dwarf.LittleEndian filename
+  (_, (cuDies, _)) <- loadElfDwarf filename
   mapM_ (putStrLn . drawTree . fmap show) $ map dieTree cuDies


### PR DESCRIPTION
The ELF headers contains information about byte order, so we can use this for loading the embedded DWARF information.  I guess it would be possible for the DWARF information to have opposite endianness to the ELF container, but I've never seen a file like that.

This is a breaking API change, so if you'd prefer I can adjust it to have a separate function for automatically detecting it from the ELF data.